### PR TITLE
fix copy link bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,9 +23,9 @@
     "web-vitals": "^2.1.4"
   },
   "scripts": {
-    "start": "cross-env PUBLIC_URL='/'; react-scripts start",
+    "start": "export PUBLIC_URL='/'; react-scripts start",
     "build": "react-scripts build",
-    "debugProd": "yarn build && serve -s build",
+    "debugProd": "yarn build; serve -s build",
     "test": "react-scripts test",
     "predeploy": "npm run build",
     "deploy": "yarn predeploy; gh-pages -d build",
@@ -51,7 +51,6 @@
     ]
   },
   "devDependencies": {
-    "cross-env": "^7.0.3",
     "eslint-plugin-react": "^7.33.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -23,9 +23,9 @@
     "web-vitals": "^2.1.4"
   },
   "scripts": {
-    "start": "export PUBLIC_URL='/'; react-scripts start",
+    "start": "cross-env PUBLIC_URL='/'; react-scripts start",
     "build": "react-scripts build",
-    "debugProd": "yarn build; serve -s build",
+    "debugProd": "yarn build && serve -s build",
     "test": "react-scripts test",
     "predeploy": "npm run build",
     "deploy": "yarn predeploy; gh-pages -d build",
@@ -51,6 +51,7 @@
     ]
   },
   "devDependencies": {
+    "cross-env": "^7.0.3",
     "eslint-plugin-react": "^7.33.2"
   }
 }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -181,7 +181,7 @@ export default function App() {
               Pick some cards below to create your ultimate deck!
             </p>
             <p>
-              The URL updates as you go, so click share and the link when you are done!
+              The URL updates as you go, so click share and copy the link when you are done!
             </p>
           </>
         ) : null}

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -342,12 +342,12 @@ function CopiedPopup(props) {
   useEffect(() => {
     // This is neccesary in production builds. IDK why.
     // No, requestAnimationFrame does not work
-    setTimeout(() => {
+    requestAnimationFrame(() => {
       const me = copiedRef.current;
       me.style.opacity = 0.0;
       me.style.transform = 'translate(-50%, -150%)';
       setTimeout(onDone, COPIED_POPUP_TIMEOUT);
-    }, 1);
+    });
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -181,7 +181,7 @@ export default function App() {
               Pick some cards below to create your ultimate deck!
             </p>
             <p>
-              The URL updates as you go, so click share and copy the link when you are done!
+              The URL updates as you go, so click share and click the link to share your build!
             </p>
           </>
         ) : null}

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -73,19 +73,21 @@ export default function App() {
   const tryToCopy = async (e) => {
     copyPasteRef.current.focus();
     copyPasteRef.current.setSelectionRange(0, window.location.href.length);
-    try {
-      await navigator.clipboard.writeText(window.location.href);
-      setSuccessfulCopies((copies) => {
-        const c = [...copies, {
-          id: Date.now().toString(36), // :)
-          x: e.clientX,
-          y: e.clientY,
-        }];
-        return c;
-      });
-    } catch {
-      // It's all good, we open the fallback option regardless
-    }
+    setTimeout(async () => {
+      try {
+        await navigator.clipboard.writeText(window.location.href);
+        setSuccessfulCopies((copies) => {
+          const c = [...copies, {
+            id: Date.now().toString(36), // :)
+            x: e.clientX,
+            y: e.clientY,
+          }];
+          return c;
+        });
+      } catch (err) {
+        // It's all good, we open the fallback option regardless
+      }
+    }, 0);
   };
 
   const deckCost = myCards
@@ -179,8 +181,7 @@ export default function App() {
               Pick some cards below to create your ultimate deck!
             </p>
             <p>
-              The URL updates as you go, so copy paste at any time to
-              share your build!
+              The URL updates as you go, so click share and the link when you are done!
             </p>
           </>
         ) : null}

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -340,8 +340,6 @@ function CopiedPopup(props) {
   const copiedRef = useRef();
 
   useEffect(() => {
-    // This is neccesary in production builds. IDK why.
-    // No, requestAnimationFrame does not work
     requestAnimationFrame(() => {
       const me = copiedRef.current;
       me.style.opacity = 0.0;

--- a/yarn.lock
+++ b/yarn.lock
@@ -3648,7 +3648,14 @@ cosmiconfig@^7.0.0:
     path-type "^4.0.0"
     yaml "^1.10.0"
 
-cross-spawn@^7.0.2, cross-spawn@^7.0.3:
+cross-env@^7.0.3:
+  version "7.0.3"
+  resolved "https://registry.yarnpkg.com/cross-env/-/cross-env-7.0.3.tgz#865264b29677dc015ba8418918965dd232fc54cf"
+  integrity sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==
+  dependencies:
+    cross-spawn "^7.0.1"
+
+cross-spawn@^7.0.1, cross-spawn@^7.0.2, cross-spawn@^7.0.3:
   version "7.0.3"
   resolved "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz"
   integrity sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==


### PR DESCRIPTION
Tested in production and development, both work fine. 

- The issue was due to the browser not having enough time to render the initial state of the animation before it's changed
-  Replaced setTimeout with requestAnimationFrame in CopiedPopup 
- Added setTimeout to tryToCopy function
- Changes home page message to work with new share button

Fixes #12