### PR TITLE
Add the ability to upload Player.log and extract decks

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -212,6 +212,11 @@ a:active {
   justify-content: space-between;
 }
 
+#decksHolder {
+  display: flex;
+  gap: 1rem;
+}
+
 .ShareContainer > label {
   flex: 0 0 auto;
 }

--- a/src/App.css
+++ b/src/App.css
@@ -180,9 +180,36 @@ a:active {
   transition: transform 0.1s;
 }
 
+.LoadMenu {
+  position: absolute;
+  bottom: 0;
+  right: 0.5rem; /* Same as .topMenu border radius */
+  z-index: -1;
+
+  width: calc(100% - 1rem);
+  padding: 1rem;
+
+  background-color: rgb(42, 21, 82);
+  border: solid white 0.25rem;
+  border-top: rgb(42, 21, 82);
+  outline: solid black 0.25rem;
+  border-bottom-left-radius: 1rem;
+  border-bottom-right-radius: 1rem;
+
+  font-size: 0.7em;
+
+  transform-origin: top;
+  transition: transform 0.1s;
+}
+
 .ShareContainer {
   display: flex;
   align-items: center;
+}
+
+.LoadContainer {
+  display: flex;
+  justify-content: space-between;
 }
 
 .ShareContainer > label {

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -116,27 +116,6 @@ export default function App() {
     const reader = new FileReader();
     reader.onload = () => {
       /* process the player.log file */
-      /*
-      The python script, for reference:
-      for line in open(log_location).readlines():
-        if line.startswith('===> {"code":0,"user"'):
-            found_user_string = line
-            break
-
-      found_user_string = found_user_string[4:].strip()
-      playerlog = json.loads(found_user_string)["user"]
-      card_inventory = playerlog["cards"]
-
-      for deck in playerlog["decks"]:
-          card_ids = []
-          print(f"Deck #{deck['index'] + 1}: {deck['name']}")
-          for card in deck["cards"]:
-              for base_card in card_inventory:
-                  if base_card["_id"] == card:
-                      card_ids.append(str(base_card["cardid"]))
-
-        print("https://friendsvsfriends.help/?deck=" + ".".join(card_ids) + "\n")
-      */
       const fileContentArray = reader.result.split('\n');
       let userString;
       for (let i = 0; i < fileContentArray.length; i += 1) {

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -99,7 +99,7 @@ export default function App() {
 
   const copyPasteRef = useRef();
   const inputRef = useRef();
-  const decksRef = useRef();
+  // const decksRef = useRef();
 
   /* https://stackoverflow.com/questions/67399620/how-to-make-open-url-on-click-on-button-in-reactjs */
   const openInNewTab = (url) => {
@@ -322,7 +322,7 @@ export default function App() {
               label="Upload Player.log"
             />
             <input ref={inputRef} type="file" id="fileInput" hidden onChange={(e) => handleFileUpload(e)} />
-            <div ref={decksRef} id="decksHolder" />
+            <div id="decksHolder" />
           </div>
         </div>
       </div>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -309,20 +309,19 @@ export default function App() {
           </div>
         </div>
         <div
-          className="ShareMenu"
+          className="LoadMenu"
           aria-hidden={!isLoadMenuOpen}
           style={{
             transform: `translate(0%, 100%) scale(1.0, ${isLoadMenuOpen ? 1.0 : 0.0})`,
           }}
         >
-          <div className="ShareContainer">
+          <div className="LoadContainer">
             {/* eslint-disable-next-line jsx-a11y/label-has-associated-control */}
             <Button
               onClick={(e) => handleButtonClick(e)}
               label="Upload Player.log"
             />
             <input ref={inputRef} type="file" id="fileInput" hidden onChange={(e) => handleFileUpload(e)} />
-            <br />
             <div ref={decksRef} id="decksHolder" />
           </div>
         </div>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -143,10 +143,13 @@ export default function App() {
         DECKS.push({ name: deck.name, url: madeurl });
       });
       root.render(
-        <div>
-          {DECKS.map((deck) => (
-            <Button label={deck.name} style={{ margin: '8px' }} onClick={() => openInNewTab(deck.url)} />))}
-        </div>,
+        DECKS.map((deck) => (
+          <Button
+            label={deck.name}
+            style={{ margin: '8px' }}
+            onClick={() => openInNewTab(deck.url)}
+          />
+        )),
       );
     };
     reader.readAsText(file);

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -99,7 +99,6 @@ export default function App() {
 
   const copyPasteRef = useRef();
   const inputRef = useRef();
-  // const decksRef = useRef();
 
   /* https://stackoverflow.com/questions/67399620/how-to-make-open-url-on-click-on-button-in-reactjs */
   const openInNewTab = (url) => {
@@ -107,7 +106,7 @@ export default function App() {
     if (newWindow) newWindow.opener = null;
   };
 
-  /* Copied and pasted from a medium article. */
+  /* https://medium.com/@ctrlaltmonique/how-to-create-a-custom-file-upload-button-in-react-with-typescript-b08150f1532e */
   function handleFileUpload(e) {
     const { files } = e.target;
     if (!files) return;


### PR DESCRIPTION
Adds a "Load" button that opens a drop down menu.
(The load menu is mutually exclusive to the share menu)

In the menu, the user can upload their Player.log file, and the decks in the file will be extracted.

Unfortunately, the spacing of the generated buttons isn't optimal.

![image](https://github.com/user-attachments/assets/5085fcd6-a93c-4088-99de-dc6a39b02928)
